### PR TITLE
added simple lua registry support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.28")
 			${CMAKE_SOURCE_DIR}/modules/Basics.ixx
 			${CMAKE_SOURCE_DIR}/modules/Generic.ixx
 			${CMAKE_SOURCE_DIR}/modules/Table.ixx
+			${CMAKE_SOURCE_DIR}/modules/Registry.ixx
 			${CMAKE_SOURCE_DIR}/modules/State.ixx
 			${CMAKE_SOURCE_DIR}/modules/Literals.ixx
 		)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,11 +14,11 @@ if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.28")
 		target_sources(luacpp
 			PUBLIC
 			FILE_SET CXX_MODULES FILES
-			${CMAKE_SOURCE_DIR}/modules/Debug.ixx
 			${CMAKE_SOURCE_DIR}/modules/Type.ixx
 			${CMAKE_SOURCE_DIR}/modules/TypeMismatchException.ixx
 			${CMAKE_SOURCE_DIR}/modules/Basics.ixx
 			${CMAKE_SOURCE_DIR}/modules/Generic.ixx
+			${CMAKE_SOURCE_DIR}/modules/Debug.ixx
 			${CMAKE_SOURCE_DIR}/modules/Table.ixx
 			${CMAKE_SOURCE_DIR}/modules/Registry.ixx
 			${CMAKE_SOURCE_DIR}/modules/State.ixx

--- a/include/luacpp/Basics.hpp
+++ b/include/luacpp/Basics.hpp
@@ -49,6 +49,7 @@ public:
 	 * @return true if the value is of the given type, false otherwise
 	*/
 	static bool isOfType(lua_State* state, Type t, int index);
+	static bool isFunction(lua_State* state, int index);
 
 	static Type getType(lua_State* state, int index);
 
@@ -100,6 +101,7 @@ public:
 		}
 	}
 
+	static void insert(lua_State* state, int index);
 	static void popStack(lua_State* state, int numValues);
 
 	static void pushNil(lua_State* state);

--- a/include/luacpp/Basics.hpp
+++ b/include/luacpp/Basics.hpp
@@ -122,7 +122,7 @@ public:
 	static const char* asString(lua_State* state, int index, size_t* len = nullptr);
 
 	static void* allocateUserData(lua_State* state, size_t size, int userValues = 0);
-
+	
 	static int calcUpValueIndex(int index);
 };
 

--- a/include/luacpp/Debug.hpp
+++ b/include/luacpp/Debug.hpp
@@ -1,6 +1,16 @@
 #ifndef LUACPP_DEBUG_HPP
 #define LUACPP_DEBUG_HPP
 
+#ifdef USE_CPP20_MODULES
+import luacpp.Generic;
+#else
+#include "Generic.hpp"
+#endif
+
+#include <vector>
+
+struct lua_State;
+
 namespace Lua {
 
 constexpr static const int srcSize = 60;
@@ -44,6 +54,10 @@ constexpr static const int MaskReturn = 1 << static_cast<int>(EventCodes::Return
 constexpr static const int MaskLine = 1 << static_cast<int>(EventCodes::Line);
 constexpr static const int MaskCount = 1 << static_cast<int>(EventCodes::Count);
 
+class Debug {
+public:
+	static std::vector<Generic> readStack(lua_State* state);
+};
 
 } // namespace Lua
 

--- a/include/luacpp/Generic.hpp
+++ b/include/luacpp/Generic.hpp
@@ -51,6 +51,8 @@ public:
 
 	static Generic fromStack(int index, lua_State* state);
 
+	bool isInteger() const;
+	bool isDouble() const;
 	bool operator==(const Generic& other) const;
 	bool operator<(const Generic& other) const;
 

--- a/include/luacpp/Registry.hpp
+++ b/include/luacpp/Registry.hpp
@@ -31,8 +31,6 @@ public:
 
 	Registry(lua_State* L);
 
-	std::map<Generic, Generic> readGeneric();
-
 	ErrorCode loadScript(Generic key, const char* src);
 	
 	template <typename T>

--- a/include/luacpp/Registry.hpp
+++ b/include/luacpp/Registry.hpp
@@ -1,0 +1,31 @@
+#ifndef LUACPP_REGISTRY_HPP
+#define LUACPP_REGISTRY_HPP
+
+#include <string>
+
+struct lua_State;
+
+namespace Lua {
+
+class Registry {
+public:
+	enum class ErrorCode {
+		Ok = 0,
+		Yield = 1,
+		RuntimeError = 2,
+		SyntaxError = 3,
+		MemoryError = 4,
+		ErrorError = 5
+	};
+	
+	Registry(lua_State* L);
+
+	ErrorCode loadScript(const char* name, const char* src);
+
+private:
+	lua_State* m_state;
+};
+
+} // namespace Lua
+
+#endif // LUACPP_REGISTRY_HPP

--- a/include/luacpp/Registry.hpp
+++ b/include/luacpp/Registry.hpp
@@ -18,7 +18,7 @@ struct lua_State;
 
 namespace Lua {
 
-class Registry {
+class Registry : public Table {
 public:
 	enum class ErrorCode {
 		Ok = 0,
@@ -39,7 +39,7 @@ public:
 		if (res == ErrorCode::Ok) {
 			Basics::pushToStack(m_state, key);
 			Basics::insert(m_state, -2);
-			setRegistryTable(m_state);
+			setTableRaw(m_state, m_tableIndex);
 		}
 		return res;
 	}
@@ -48,36 +48,19 @@ public:
 	
 	template <typename T>
 	ErrorCode getScript(T key) {
-		if (getEntry(key) != Type::Function) {
+		if (getElement(key) != Type::Function) {
 			Basics::popStack(m_state, 1);
 			return ErrorCode::RuntimeError;
 		}
 		return ErrorCode::Ok;
 	}
 
-	template <typename T, typename U>
-	void setEntry(T key, U value) {
-		Basics::pushToStack(m_state, key);
-		Basics::pushToStack(m_state, value);
-		setRegistryTable(m_state);
-	}
-
-	template <typename T>
-	Type getEntry(T key) {
-		Basics::pushToStack(m_state, key);
-		return getRegistryTable(m_state);
-	}
-
 	bool copyContent(Registry& other);
 
 private:
 	static ErrorCode loadString(lua_State* state, const char* src);
-	static Type getRegistryTable(lua_State* state);
-	static void setRegistryTable(lua_State* state);
 	static bool isUserDefinedEntry(const Registry& registry);
 	static void copyEntry(lua_State* src, lua_State* dst);	
-
-	lua_State* m_state;
 };
 
 } // namespace Lua

--- a/include/luacpp/Registry.hpp
+++ b/include/luacpp/Registry.hpp
@@ -2,14 +2,17 @@
 #define LUACPP_REGISTRY_HPP
 
 #ifdef USE_CPP20_MODULES
-import luacpp.Generic;
 import luacpp.Basics;
+import luacpp.Generic;
+import luacpp.Table;
 #else
-#include "Generic.hpp"
 #include "Basics.hpp"
+#include "Generic.hpp"
+#include "Table.hpp"
 #endif
 
 #include <string>
+#include <map>
 
 struct lua_State;
 
@@ -27,6 +30,8 @@ public:
 	};
 
 	Registry(lua_State* L);
+
+	std::map<Generic, Generic> readGeneric();
 
 	ErrorCode loadScript(Generic key, const char* src);
 	
@@ -65,10 +70,15 @@ public:
 		return getRegistryTable(m_state);
 	}
 
+	bool copyContent(Registry& other);
+
 private:
 	static ErrorCode loadString(lua_State* state, const char* src);
 	static Type getRegistryTable(lua_State* state);
 	static void setRegistryTable(lua_State* state);
+	static bool isUserDefinedEntry(const Registry& registry);
+	static void copyEntry(lua_State* src, lua_State* dst);	
+
 	lua_State* m_state;
 };
 

--- a/include/luacpp/State.hpp
+++ b/include/luacpp/State.hpp
@@ -403,11 +403,7 @@ public:
 	 * @return A list of all values on the stack (given as Generic objects)
 	*/
 	std::vector<Generic> getStack() {
-		std::vector<Generic> stack;
-		for (int i = 1, stackSize = getStackSize(); i <= stackSize; ++i) {
-			stack.push_back(Generic::fromStack(i, m_state));
-		}
-		return stack;
+		return Debug::readStack(m_state);
 	}
 
 	/**

--- a/include/luacpp/State.hpp
+++ b/include/luacpp/State.hpp
@@ -3,12 +3,14 @@
 
 #ifdef USE_CPP20_MODULES
 import luacpp.Basics;
+import luacpp.Registry;
 import luacpp.Table;
 import luacpp.Generic;
 import luacpp.Debug;
 #else
 #include "Basics.hpp"
 #include "Table.hpp"
+#include "Registry.hpp"
 #include "Generic.hpp"
 #include "Debug.hpp"
 #endif
@@ -193,26 +195,35 @@ public:
 	int overrideLuaFunction(const char* name, NativeFunction func);
 
 	/**
-	 * @brief Load a script into the global scope
-	 * The script is than available as a function with the name provided by the source (e.g. the file name)
-	 * You can than execute the script by calling the function with the same name.
-	 * This way you can load multiple scripts into the same lua state but this also comes with the risk of name collisions.
-	 * This scripts will share the same variables and functions.
-	 * This is also useful if you want to run a script multiple times.
+	 * @brief Load a script into the registry
+	 * @param name The name of the script
 	 * @param code The source code of the script
 	*/
-	int loadScriptIntoGlobal(const char* name, const char* code);
+	template <typename T>
+	int loadScript(T key, const char* code) {
+		return static_cast<int>(m_registry.loadScript<T>(key, code));
+	}
+
+	template <typename T>
+	int loadScript(T key, const std::string& code) { return loadScript<T>(key, code.c_str()); }
 
 	/**
-	 * @brief Load a script into the global scope
-	 * The script is than available as a function with the name provided by the source (e.g. the file name)
-	 * You can than execute the script by calling the function with the same name.
-	 * This way you can load multiple scripts into the same lua state but this also comes with the risk of name collisions.
-	 * This scripts will share the same variables and functions.
-	 * This is also useful if you want to run a script multiple times.
-	 * @param code The source code of the script
-	*/
-	int loadScriptIntoGlobal(const char* name, const std::string& code) { return loadScriptIntoGlobal(name, code.c_str()); }
+	 * @brief Execute a script from the registry
+	 * This method tries to load a script from the registry and executes it immediately. The script will be
+	 * popped from the stack after execution.
+	 * @param name The key in the registry where the script is stored
+	 */
+	template <typename T>
+	int executeScript(T key) {
+		int ec = static_cast<int>(m_registry.getScript(key));
+		if (ec == static_cast<int>(Registry::ErrorCode::Ok)) {
+			ec = callFunction(0, 0);
+			if (ec != 0) {
+				popStack(1); //pop the error message ToDo: improve error handling
+			}
+		}
+		return ec;
+	}
 
 	/**
 	 * @brief Load and execute a script
@@ -445,6 +456,7 @@ private:
 	static std::map<lua_State*, DebugHook> s_debugHooks; ///< list of debug hooks (one per lua state)
 
 	lua_State* m_state; ///< instance of the lua virtual machine
+	Registry m_registry; ///< registry for user defined functions
 	bool m_externalState; ///< true if the state was provided by the user, false if it was created by this class
 	std::vector<Method> m_callbacks; ///< list of registered methods
 	std::vector<std::string> m_errorList; ///< list of errors that occured during script execution

--- a/include/luacpp/Table.hpp
+++ b/include/luacpp/Table.hpp
@@ -28,7 +28,7 @@ public:
 	void setElement(Key key, Value value) {
 		Basics::pushToStack<Key>(m_state, key);
 		Basics::pushToStack<Value>(m_state, value);
-		setTable(m_state, -3, m_triggerMetaMethods);
+		setTable(m_state, m_tableIndex, m_triggerMetaMethods);
 	}
 
 	template <typename T>

--- a/include/luacpp/Table.hpp
+++ b/include/luacpp/Table.hpp
@@ -28,7 +28,17 @@ public:
 	void setElement(Key key, Value value) {
 		Basics::pushToStack<Key>(m_state, key);
 		Basics::pushToStack<Value>(m_state, value);
-		setTable(m_state, m_tableIndex, m_triggerMetaMethods);
+		if (m_triggerMetaMethods) {
+			setTable(m_state, m_tableIndex);
+		} else {
+			setTableRaw(m_state, m_tableIndex);
+		}
+	}
+
+	template <typename T>
+	Type getElement(T key) {
+		Basics::pushToStack(m_state, key);
+		return m_triggerMetaMethods ? getTable(m_state, m_tableIndex) : getTableRaw(m_state, m_tableIndex);
 	}
 
 	template <typename T>
@@ -136,7 +146,7 @@ public:
 	*/
 	bool assignMetaTable(const char* name);
 	
-private:
+protected:
 	/**
 	 * @brief applies the given key to the value on top of the stack
 	 * 
@@ -147,7 +157,11 @@ private:
 
 	static Type getField(lua_State* state, int idx, const char* key);
 
-	static void setTable(lua_State* state, int idx, bool triggerMetaMethods);
+	static Type getTable(lua_State* state, int idx);
+	static Type getTableRaw(lua_State* state, int idx);
+
+	static void setTable(lua_State* state, int idx);
+	static void setTableRaw(lua_State* state, int idx);
 
 	static int getNext(lua_State* state, int idx);
 

--- a/modules/Debug.ixx
+++ b/modules/Debug.ixx
@@ -1,5 +1,6 @@
 module;
 #include <Debug.hpp>
+#include "../src/Debug.cpp"
 
 export module luacpp.Debug;
 
@@ -11,4 +12,6 @@ export {
 	using Lua::MaskReturn;
 	using Lua::MaskLine;
 	using Lua::MaskCount;
+
+	using Lua::Debug;
 }

--- a/modules/Registry.ixx
+++ b/modules/Registry.ixx
@@ -1,0 +1,9 @@
+module;
+#include <Registry.hpp>
+#include "../src/Registry.cpp"
+
+export module luacpp.Registry;
+
+export {
+	using Lua::Registry;
+}

--- a/modules/Table.ixx
+++ b/modules/Table.ixx
@@ -1,9 +1,9 @@
 module;
-#include <LuaTable.hpp>
-#include "../src/LuaTable.cpp"
+#include <Table.hpp>
+#include "../src/Table.cpp"
 
 export module luacpp.Table;
 
 export {
-	using Lua::LuaTable;
+	using Lua::Table;
 }

--- a/src/Basics.cpp
+++ b/src/Basics.cpp
@@ -18,9 +18,16 @@ bool Basics::isOfType(lua_State* state, Type type, int index) {
 	}
 	return false;
 }
+bool Basics::isFunction(lua_State* state, int index) {
+	return lua_isfunction(state, index);
+}
 
 Type Basics::getType(lua_State* state, int index) {
 	return static_cast<Type>(lua_type(state, index));
+}
+
+void Basics::insert(lua_State* state, int index) {
+	lua_insert(state, index);
 }
 
 void Basics::popStack(lua_State* state, int numValues) {

--- a/src/Debug.cpp
+++ b/src/Debug.cpp
@@ -1,0 +1,15 @@
+#include <Debug.hpp>
+#include <lua/lua.hpp>
+
+namespace Lua {
+
+std::vector<Generic> Debug::readStack(lua_State* state) {
+    std::vector<Generic> stack;
+    const int stackSize = lua_gettop(state);
+    for (int i = 1; i <= stackSize; ++i) {
+        stack.push_back(Generic::fromStack(i, state));
+    }
+    return stack;
+}
+
+} // namespace Lua

--- a/src/Generic.cpp
+++ b/src/Generic.cpp
@@ -85,6 +85,9 @@ Generic Generic::fromStack(int index, lua_State* state) {
 	return generic;
 }
 
+bool Generic::isInteger() const { return std::holds_alternative<int64_t>(m_value); }
+bool Generic::isDouble() const { return std::holds_alternative<double>(m_value); }
+
 bool Generic::operator==(const Generic& other) const {
 	return m_type == other.m_type && m_value == other.m_value;
 }

--- a/src/Registry.cpp
+++ b/src/Registry.cpp
@@ -5,11 +5,6 @@ namespace Lua {
 
 Registry::Registry(lua_State* L) : m_state(L) {}
 
-std::map<Generic, Generic> Registry::readGeneric() {
-	Table table(m_state);
-	return table.readGeneric();
-}
-
 Registry::ErrorCode Registry::loadScript(Generic key, const char* src) {
 	switch (key.getType()) {
 		case Type::Boolean: return loadScript(key.get<bool>(), src);

--- a/src/Registry.cpp
+++ b/src/Registry.cpp
@@ -3,7 +3,7 @@
 
 namespace Lua {
 
-Registry::Registry(lua_State* L) : m_state(L) {}
+Registry::Registry(lua_State* L) : Table(L, LUA_REGISTRYINDEX, false) {}
 
 Registry::ErrorCode Registry::loadScript(Generic key, const char* src) {
 	switch (key.getType()) {
@@ -46,14 +46,6 @@ bool Registry::copyContent(Registry& other) {
 
 Registry::ErrorCode Registry::loadString(lua_State* state, const char* src) {
 	return static_cast<ErrorCode>(luaL_loadstring(state, src));
-}
-
-Type Registry::getRegistryTable(lua_State* state) {	
-	return static_cast<Type>(lua_rawget(state, LUA_REGISTRYINDEX));
-}
-
-void Registry::setRegistryTable(lua_State* state) {
-	lua_rawset(state, LUA_REGISTRYINDEX);
 }
 
 bool Registry::isUserDefinedEntry(const Registry& registry) {

--- a/src/Registry.cpp
+++ b/src/Registry.cpp
@@ -5,16 +5,44 @@ namespace Lua {
 
 Registry::Registry(lua_State* L) : m_state(L) {}
 
-Registry::ErrorCode Registry::loadScript(const char* name, const char* src) {
-	ErrorCode res = static_cast<ErrorCode>(luaL_loadstring(m_state, src));
-	if (res == ErrorCode::Ok) {
-		lua_pushstring(m_state, name);
-		lua_pushvalue(m_state, -2);
-		lua_settable(m_state, LUA_REGISTRYINDEX);
+Registry::ErrorCode Registry::loadScript(Generic key, const char* src) {
+	switch (key.getType()) {
+		case Type::Boolean: return loadScript(key.get<bool>(), src);
+		case Type::Number: 
+			if (key.isInteger()) {
+				return loadScript(key.get<int64_t>(), src);
+			}
+			return loadScript(key.get<double>(), src);
+		case Type::String: return loadScript(key.get<std::string>().c_str(), src);
+		default: return ErrorCode::ErrorError;
+	};
+	return ErrorCode::RuntimeError;
+}
 
-		lua_pop(m_state, 1);
-	}
-	return res;
+Registry::ErrorCode Registry::getScript(Generic key) {
+	switch (key.getType()) {
+		case Type::Boolean: return getScript(key.get<bool>());
+		case Type::Number: 
+			if (key.isInteger()) {
+				return getScript(key.get<int64_t>());
+			}
+			return getScript(key.get<double>());
+		case Type::String: return getScript(key.get<std::string>().c_str());
+		default: return ErrorCode::ErrorError;
+	};
+	return ErrorCode::RuntimeError;
+}
+
+Registry::ErrorCode Registry::loadString(lua_State* state, const char* src) {
+	return static_cast<ErrorCode>(luaL_loadstring(state, src));
+}
+
+Type Registry::getRegistryTable(lua_State* state) {
+	return static_cast<Type>(lua_gettable(state, LUA_REGISTRYINDEX));
+}
+
+void Registry::setRegistryTable(lua_State* state) {
+	lua_settable(state, LUA_REGISTRYINDEX);
 }
 
 } // namespace Lua

--- a/src/Registry.cpp
+++ b/src/Registry.cpp
@@ -5,6 +5,11 @@ namespace Lua {
 
 Registry::Registry(lua_State* L) : m_state(L) {}
 
+std::map<Generic, Generic> Registry::readGeneric() {
+	Table table(m_state);
+	return table.readGeneric();
+}
+
 Registry::ErrorCode Registry::loadScript(Generic key, const char* src) {
 	switch (key.getType()) {
 		case Type::Boolean: return loadScript(key.get<bool>(), src);
@@ -33,16 +38,73 @@ Registry::ErrorCode Registry::getScript(Generic key) {
 	return ErrorCode::RuntimeError;
 }
 
+bool Registry::copyContent(Registry& other) {
+	lua_pushnil(other.m_state);
+	while (lua_next(other.m_state, LUA_REGISTRYINDEX) != 0) {
+		if (isUserDefinedEntry(other)) {
+			copyEntry(other.m_state, m_state);
+		}
+		lua_pop(other.m_state, 1);
+	}
+	return true;
+}
+
 Registry::ErrorCode Registry::loadString(lua_State* state, const char* src) {
 	return static_cast<ErrorCode>(luaL_loadstring(state, src));
 }
 
-Type Registry::getRegistryTable(lua_State* state) {
-	return static_cast<Type>(lua_gettable(state, LUA_REGISTRYINDEX));
+Type Registry::getRegistryTable(lua_State* state) {	
+	return static_cast<Type>(lua_rawget(state, LUA_REGISTRYINDEX));
 }
 
 void Registry::setRegistryTable(lua_State* state) {
-	lua_settable(state, LUA_REGISTRYINDEX);
+	lua_rawset(state, LUA_REGISTRYINDEX);
+}
+
+bool Registry::isUserDefinedEntry(const Registry& registry) {
+	int type = lua_type(registry.m_state, -2);
+	switch (type) {
+		case LUA_TSTRING:
+			if (lua_tostring(registry.m_state, -2)[0] == '_') {
+				return false;
+			}
+			break;
+		case LUA_TNUMBER:
+			break;
+		default:
+			return false;
+	}
+
+	type = lua_type(registry.m_state, -1);
+	return type == LUA_TSTRING || type == LUA_TNUMBER || type == LUA_TBOOLEAN;
+}
+
+void Registry::copyEntry(lua_State* src, lua_State* dst) {
+	//stack now contains: -1 => value; -2 => key
+
+	if (lua_type(src, -2) == LUA_TSTRING) {
+		lua_pushstring(dst, lua_tostring(src, -2));
+	} else if (lua_type(src, -2) == LUA_TNUMBER) {
+		lua_pushnumber(dst, lua_tonumber(src, -2));
+	} else {
+		return;
+	}
+
+	switch (lua_type(src, -1)) {
+		case LUA_TSTRING:
+			lua_pushstring(dst, lua_tostring(src, -1));
+			break;
+		case LUA_TNUMBER:
+			lua_pushnumber(dst, lua_tonumber(src, -1));
+			break;
+		case LUA_TBOOLEAN:
+			lua_pushboolean(dst, lua_toboolean(src, -1));
+			break;
+		default:
+			lua_pop(dst, 1);
+			return;
+	}
+	lua_rawset(dst, LUA_REGISTRYINDEX);
 }
 
 } // namespace Lua

--- a/src/Registry.cpp
+++ b/src/Registry.cpp
@@ -1,0 +1,20 @@
+#include <Registry.hpp>
+#include <lua/lua.hpp>
+
+namespace Lua {
+
+Registry::Registry(lua_State* L) : m_state(L) {}
+
+Registry::ErrorCode Registry::loadScript(const char* name, const char* src) {
+	ErrorCode res = static_cast<ErrorCode>(luaL_loadstring(m_state, src));
+	if (res == ErrorCode::Ok) {
+		lua_pushstring(m_state, name);
+		lua_pushvalue(m_state, -2);
+		lua_settable(m_state, LUA_REGISTRYINDEX);
+
+		lua_pop(m_state, 1);
+	}
+	return res;
+}
+
+} // namespace Lua

--- a/src/Table.cpp
+++ b/src/Table.cpp
@@ -55,12 +55,19 @@ Type Table::getField(lua_State* state, int idx, const char* key) {
 	return static_cast<Type>(lua_getfield(state, idx, key));
 }
 
-void Table::setTable(lua_State* state, int idx, bool triggerMetaMethods) {
-	if (triggerMetaMethods) {
-		lua_settable(state, idx);
-	} else {
-		lua_rawset(state, idx);
-	}
+Type Table::getTable(lua_State* state, int idx) {
+	return static_cast<Type>(lua_gettable(state, idx));
+}
+Type Table::getTableRaw(lua_State* state, int idx) {
+	return static_cast<Type>(lua_rawget(state, idx));
+}
+
+void Table::setTable(lua_State* state, int idx) {
+	lua_rawset(state, idx);
+}
+
+void Table::setTableRaw(lua_State* state, int idx) {
+	lua_rawset(state, idx);
 }
 
 int Table::getNext(lua_State* state, int idx) {

--- a/test/RegistryTest.cpp
+++ b/test/RegistryTest.cpp
@@ -22,18 +22,18 @@ protected:
 	Registry m_registry;
 };
 
-TEST_F(RegistryTest, setEntry_getEntry) {
-	m_registry.setEntry("test", 42);
-	m_registry.setEntry(42, "test");
-	m_registry.setEntry(43.0, true);
+TEST_F(RegistryTest, setElement_getElement) {
+	m_registry.setElement("test", 42);
+	m_registry.setElement(42, "test");
+	m_registry.setElement(43.0, true);
 
-	EXPECT_EQ(m_registry.getEntry("test"), Type::Number);
+	EXPECT_EQ(m_registry.getElement("test"), Type::Number);
 	EXPECT_EQ(Basics::getStackValue<int>(m_state, -1), 42);
 	
-	EXPECT_EQ(m_registry.getEntry(42), Type::String);
+	EXPECT_EQ(m_registry.getElement(42), Type::String);
 	EXPECT_EQ(Basics::getStackValue<std::string>(m_state, -1), "test");
 	
-	EXPECT_EQ(m_registry.getEntry(43.0), Type::Boolean);
+	EXPECT_EQ(m_registry.getElement(43.0), Type::Boolean);
 	EXPECT_EQ(Basics::getStackValue<bool>(m_state, -1), true);
 }
 
@@ -60,27 +60,27 @@ TEST_F(RegistryTest, loadScript_invalidSyntax) {
 
 TEST_F(RegistryTest, copyContent) {
 	constexpr const char* test = "test";
-	m_registry.setEntry("test", 42);
-	m_registry.setEntry(42, "test");
-	m_registry.setEntry(43.0, true);
+	m_registry.setElement("test", 42);
+	m_registry.setElement(42, "test");
+	m_registry.setElement(43.0, true);
 
 	lua_State* otherState = luaL_newstate();
 	Registry cpy(otherState);
 	cpy.copyContent(m_registry);
 
-	EXPECT_EQ(m_registry.getEntry("test"), Type::Number);
+	EXPECT_EQ(m_registry.getElement("test"), Type::Number);
 	EXPECT_EQ(Basics::getStackValue<int>(m_state, -1), 42);
-	EXPECT_EQ(cpy.getEntry("test"), Type::Number);
+	EXPECT_EQ(cpy.getElement("test"), Type::Number);
 	EXPECT_EQ(Basics::getStackValue<int>(otherState, -1), 42);
 
-	EXPECT_EQ(m_registry.getEntry(42), Type::String);
+	EXPECT_EQ(m_registry.getElement(42), Type::String);
 	EXPECT_EQ(Basics::getStackValue<std::string>(m_state, -1), "test");
-	EXPECT_EQ(cpy.getEntry(42), Type::String);
+	EXPECT_EQ(cpy.getElement(42), Type::String);
 	EXPECT_EQ(Basics::getStackValue<std::string>(otherState, -1), "test");
 
-	EXPECT_EQ(m_registry.getEntry(43.0), Type::Boolean);
+	EXPECT_EQ(m_registry.getElement(43.0), Type::Boolean);
 	EXPECT_EQ(Basics::getStackValue<bool>(m_state, -1), true);
-	EXPECT_EQ(cpy.getEntry(43.0), Type::Boolean);
+	EXPECT_EQ(cpy.getElement(43.0), Type::Boolean);
 	EXPECT_EQ(Basics::getStackValue<bool>(otherState, -1), true);
 
 	lua_close(otherState);

--- a/test/RegistryTest.cpp
+++ b/test/RegistryTest.cpp
@@ -1,0 +1,51 @@
+#include <gtest/gtest.h>
+
+#ifdef USE_CPP20_MODULES
+import luacpp.Registry;
+#else
+#include <luacpp/Registry.hpp>
+#endif
+
+#include <lua/lua.hpp>
+
+
+namespace Lua {
+
+class RegistryTest : public ::testing::Test {
+public:
+	RegistryTest() : m_state(luaL_newstate()), m_registry(m_state) {
+		luaL_openlibs(m_state);
+	}
+protected:
+	lua_State* m_state;
+	Registry m_registry;
+};
+
+TEST_F(RegistryTest, setValue) {
+	m_registry.setEntry("test", 42);
+	EXPECT_EQ(m_registry.getEntry("test"), Type::Number);
+	EXPECT_EQ(Basics::getStackValue<int>(m_state, -1), 42);
+
+	m_registry.setEntry(42, "test");
+	EXPECT_EQ(m_registry.getEntry(42), Type::String);
+	EXPECT_EQ(Basics::getStackValue<std::string>(m_state, -1), "test");
+
+	m_registry.setEntry(42.0, true);
+	EXPECT_EQ(m_registry.getEntry(42.0), Type::Boolean);
+	EXPECT_EQ(Basics::getStackValue<bool>(m_state, -1), true);
+}
+
+TEST_F(RegistryTest, loadScript) {
+	const char* script = "print(\"Hello, World!\")";
+	Registry::ErrorCode res = m_registry.loadScript(1, script);
+	ASSERT_EQ(res, Registry::ErrorCode::Ok);
+
+	res = m_registry.getScript(1);
+	ASSERT_EQ(res, Registry::ErrorCode::Ok);
+
+	//just test if the function gets executed
+	EXPECT_EQ(lua_pcall(m_state, 0, 0, 0), 0);
+}
+
+
+} // namespace Lua

--- a/test/StateTest.cpp
+++ b/test/StateTest.cpp
@@ -118,6 +118,30 @@ TEST_F(StateTest, writeVariable) {
 	EXPECT_EQ(script.readVariable<int>("y"), 12);
 }
 
+TEST_F(StateTest, executeScriptFromRegistry) {
+	constexpr static const char* const ScriptKey = "test";
+	const char* src = R"(
+		-- This is a Lua script
+		x = x + 1
+	)";
+
+	//load the script into the registry
+	State script(State::LibNone);
+	ASSERT_EQ(script.loadScript(ScriptKey, src), 0);
+	EXPECT_EQ(script.getStackSize(), 0);
+
+	//execute the script
+	script.writeVariable("x", 0);
+	EXPECT_EQ(script.executeScript(ScriptKey), 0);
+	EXPECT_EQ(script.getStackSize(), 0);
+	EXPECT_EQ(script.readVariable<int>("x"), 1);
+
+	//execute the script again
+	EXPECT_EQ(script.executeScript(ScriptKey), 0);
+	EXPECT_EQ(script.getStackSize(), 0);
+	EXPECT_EQ(script.readVariable<int>("x"), 2);
+}
+
 TEST_F(StateTest, simpleFunctionWithReturnValue) {
 	const char* src = R"(
 		function sqr(x)


### PR DESCRIPTION
Every Lua state object now owns a Registry object which provides access to the lua registry. For now it is used to load a script into the registry for later execution.

loadScriptIntoGlobal has been removed